### PR TITLE
Changed minimum tick time for non-dedicated servers

### DIFF
--- a/server.cs
+++ b/server.cs
@@ -41,7 +41,10 @@ function serverCmdLST(%client, %time)
 {
 	if(%client.isAdmin || %client.isSuperAdmin)
 	{
-		$LBC::Opts::Time = mClamp(%time, 1, 999999); //Weird jittery behavior when set to 0
+		if($Server::Dedicated)
+			$LBC::Opts::Time = mClamp(%time, 0, 999999);
+		else
+			$LBC::Opts::Time = mClamp(%time, 1, 999999);
 		messageAll('', '\c3%1\c6 has set the logic tick time to \c3%2\c6 millisecond%3.', %client.name, $LBC::Opts::Time, $LBC::Opts::Time == 1 ? "":"s");
 	}
 }

--- a/server.cs
+++ b/server.cs
@@ -42,7 +42,7 @@ function serverCmdLST(%client, %time)
 	if(%client.isAdmin || %client.isSuperAdmin)
 	{
 		$LBC::Opts::Time = mClamp(%time, 1, 999999); //Weird jittery behavior when set to 0
-		messageAll('', '\c3%1\c6 has set the logic tick time to \c3%2\c6 millisecond%3.', %client.name, $LBC::Opts::Time, %time == 1 ? "":"s");
+		messageAll('', '\c3%1\c6 has set the logic tick time to \c3%2\c6 milliseconds.', %client.name, $LBC::Opts::Time, $LBC::Opts::Time == 1 ? "":"s");
 	}
 }
 

--- a/server.cs
+++ b/server.cs
@@ -37,7 +37,7 @@ function serverCmdLST(%client, %time)
 {
 	if(%client.isAdmin || %client.isSuperAdmin)
 	{
-		$LBC::Opts::Time = mClamp(%time, 0, 999999);
+		$LBC::Opts::Time = mClamp(%time, 1, 999999); //Weird jittery behavior when set to 0
 		messageAll('', '\c3%1\c6 has set the logic tick time to \c3%2\c6 millisecond%3.', %client.name, $LBC::Opts::Time, %time == 1 ? "":"s");
 	}
 }

--- a/server.cs
+++ b/server.cs
@@ -42,7 +42,7 @@ function serverCmdLST(%client, %time)
 	if(%client.isAdmin || %client.isSuperAdmin)
 	{
 		$LBC::Opts::Time = mClamp(%time, 1, 999999); //Weird jittery behavior when set to 0
-		messageAll('', '\c3%1\c6 has set the logic tick time to \c3%2\c6 milliseconds.', %client.name, $LBC::Opts::Time, $LBC::Opts::Time == 1 ? "":"s");
+		messageAll('', '\c3%1\c6 has set the logic tick time to \c3%2\c6 millisecond%3.', %client.name, $LBC::Opts::Time, $LBC::Opts::Time == 1 ? "":"s");
 	}
 }
 


### PR DESCRIPTION
Changed minimum clamp for time from 0 to 1 due to weird jittery behavior noticed when hosting non dedicated server